### PR TITLE
IDE-3909 Add new LfierayMavenWorkspace project to support workspace project delete action

### DIFF
--- a/maven/plugins/com.liferay.ide.maven.core/src/com/liferay/ide/maven/core/FacetedMavenProject.java
+++ b/maven/plugins/com.liferay.ide.maven.core/src/com/liferay/ide/maven/core/FacetedMavenProject.java
@@ -51,12 +51,12 @@ public class FacetedMavenProject extends LiferayMavenProject implements IWebProj
 		_flexibleProject = new FlexibleProject(project) {
 
 			@Override
-			public String getProperty(String key, String defaultValue) {
+			public IPath getLibraryPath(String filename) {
 				return null;
 			}
 
 			@Override
-			public IPath getLibraryPath(String filename) {
+			public String getProperty(String key, String defaultValue) {
 				return null;
 			}
 

--- a/maven/plugins/com.liferay.ide.maven.core/src/com/liferay/ide/maven/core/LiferayMavenProjectConfigurator.java
+++ b/maven/plugins/com.liferay.ide.maven.core/src/com/liferay/ide/maven/core/LiferayMavenProjectConfigurator.java
@@ -454,6 +454,7 @@ public class LiferayMavenProjectConfigurator extends AbstractProjectConfigurator
 
 				if (projectFacet.getId().contains("liferay.")) {
 					retval = fv;
+
 					break;
 				}
 			}

--- a/maven/plugins/com.liferay.ide.maven.core/src/com/liferay/ide/maven/core/LiferayMavenProjectProvider.java
+++ b/maven/plugins/com.liferay.ide.maven.core/src/com/liferay/ide/maven/core/LiferayMavenProjectProvider.java
@@ -259,6 +259,7 @@ public class LiferayMavenProjectProvider extends AbstractLiferayProjectProvider 
 						// return dummy maven project that can't lookup docroot resources
 
 						return new LiferayMavenProject(project) {
+
 							@Override
 							public IFolder[] getSourceFolders() {
 								return null;

--- a/maven/plugins/com.liferay.ide.maven.core/src/com/liferay/ide/maven/core/LiferayMavenWorkspaceProject.java
+++ b/maven/plugins/com.liferay.ide.maven.core/src/com/liferay/ide/maven/core/LiferayMavenWorkspaceProject.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.ide.maven.core;
+
+import com.liferay.ide.project.core.IProjectBuilder;
+import com.liferay.ide.project.core.IWorkspaceProjectBuilder;
+import com.liferay.ide.project.core.LiferayWorkspaceProject;
+
+import org.eclipse.core.resources.IProject;
+
+/**
+ * @author Simon Jiang
+ */
+public class LiferayMavenWorkspaceProject extends LiferayWorkspaceProject {
+
+	public LiferayMavenWorkspaceProject(IProject project) {
+		super(project);
+	}
+
+	@Override
+	public <T> T adapt(Class<T> adapterType) {
+		if (IProjectBuilder.class.equals(adapterType) || IWorkspaceProjectBuilder.class.equals(adapterType)) {
+			IProjectBuilder projectBuilder = new MavenProjectBuilder(getProject());
+
+			return adapterType.cast(projectBuilder);
+		}
+
+		return super.adapt(adapterType);
+	}
+
+}

--- a/maven/plugins/com.liferay.ide.maven.core/src/com/liferay/ide/maven/core/LiferayMavenWorkspaceProjectProvider.java
+++ b/maven/plugins/com.liferay.ide.maven.core/src/com/liferay/ide/maven/core/LiferayMavenWorkspaceProjectProvider.java
@@ -14,9 +14,11 @@
 
 package com.liferay.ide.maven.core;
 
+import com.liferay.ide.core.ILiferayProject;
 import com.liferay.ide.project.core.ProjectCore;
 import com.liferay.ide.project.core.modules.BladeCLI;
 import com.liferay.ide.project.core.modules.BladeCLIException;
+import com.liferay.ide.project.core.util.LiferayWorkspaceUtil;
 import com.liferay.ide.project.core.util.ProjectUtil;
 import com.liferay.ide.project.core.workspace.NewLiferayWorkspaceOp;
 import com.liferay.ide.project.core.workspace.NewLiferayWorkspaceProjectProvider;
@@ -34,6 +36,7 @@ import org.eclipse.sapphire.platform.PathBridge;
 /**
  * @author Joye Luo
  * @author Andy Wu
+ * @author Simon Jiang
  */
 public class LiferayMavenWorkspaceProjectProvider
 	extends LiferayMavenProjectProvider implements NewLiferayWorkspaceProjectProvider<NewLiferayWorkspaceOp> {
@@ -95,6 +98,24 @@ public class LiferayMavenWorkspaceProjectProvider
 		}
 
 		return retval;
+	}
+
+	@Override
+	public synchronized ILiferayProject provide(Object adaptable) {
+		if (adaptable instanceof IProject) {
+			final IProject project = (IProject)adaptable;
+
+			try {
+				if (MavenUtil.isMavenProject(project) && LiferayWorkspaceUtil.isValidWorkspace(project)) {
+					return new LiferayMavenWorkspaceProject(project);
+				}
+			}
+			catch (Exception e) {
+				return null;
+			}
+		}
+
+		return null;
 	}
 
 	@Override

--- a/maven/plugins/com.liferay.ide.maven.core/src/com/liferay/ide/maven/core/LiferayPortalMaven.java
+++ b/maven/plugins/com.liferay.ide.maven.core/src/com/liferay/ide/maven/core/LiferayPortalMaven.java
@@ -135,6 +135,7 @@ public class LiferayPortalMaven implements ILiferayPortal {
 									dep.getGroupId().startsWith("com.liferay")) {
 
 									liferayVersion = dep.getVersion();
+
 									break;
 								}
 							}

--- a/maven/plugins/com.liferay.ide.maven.core/src/com/liferay/ide/maven/core/MavenProjectBuilder.java
+++ b/maven/plugins/com.liferay.ide.maven.core/src/com/liferay/ide/maven/core/MavenProjectBuilder.java
@@ -426,6 +426,7 @@ public class MavenProjectBuilder extends AbstractProjectBuilder implements IWork
 
 					if (existedKey.equals(newKey)) {
 						existed = true;
+
 						break;
 					}
 				}

--- a/maven/plugins/com.liferay.ide.maven.core/src/com/liferay/ide/maven/core/NewMavenJSFModuleProjectProvider.java
+++ b/maven/plugins/com.liferay.ide.maven.core/src/com/liferay/ide/maven/core/NewMavenJSFModuleProjectProvider.java
@@ -183,6 +183,7 @@ public class NewMavenJSFModuleProjectProvider
 				for (String folder : folders) {
 					if (projectLocation.lastSegment().endsWith(folder)) {
 						appendWarFolder = true;
+
 						break;
 					}
 				}

--- a/tools/plugins/com.liferay.ide.core/src/com/liferay/ide/core/BaseLiferayProject.java
+++ b/tools/plugins/com.liferay.ide.core/src/com/liferay/ide/core/BaseLiferayProject.java
@@ -34,7 +34,7 @@ import org.eclipse.jdt.core.JavaModelException;
 public abstract class BaseLiferayProject implements ILiferayProject {
 
 	public BaseLiferayProject(IProject project) {
-		_project = project;
+		this.project = project;
 	}
 
 	public <T> T adapt(Class<T> adapterType) {
@@ -56,11 +56,11 @@ public abstract class BaseLiferayProject implements ILiferayProject {
 	}
 
 	public IProject getProject() {
-		return _project;
+		return project;
 	}
 
 	public IFolder getSourceFolder(String classification) {
-		List<IFolder> folders = CoreUtil.getSourceFolders(JavaCore.create(_project));
+		List<IFolder> folders = CoreUtil.getSourceFolders(JavaCore.create(project));
 
 		if (ListUtil.isEmpty(folders)) {
 			return null;
@@ -111,6 +111,6 @@ public abstract class BaseLiferayProject implements ILiferayProject {
 		return false;
 	}
 
-	private IProject _project;
+	protected IProject project;
 
 }

--- a/tools/plugins/com.liferay.ide.gradle.core/src/com/liferay/ide/gradle/core/GradleProjectProvider.java
+++ b/tools/plugins/com.liferay.ide.gradle.core/src/com/liferay/ide/gradle/core/GradleProjectProvider.java
@@ -172,8 +172,9 @@ public class GradleProjectProvider
 			IProject project = (IProject)adaptable;
 
 			try {
-				if (!LiferayWorkspaceUtil.isValidWorkspace(project) &&
-						LiferayNature.hasNature(project) && GradleProjectNature.isPresentOn(project)) {
+				if (!LiferayWorkspaceUtil.isValidWorkspace(project) && LiferayNature.hasNature(project) &&
+					GradleProjectNature.isPresentOn(project)) {
+
 					if (ProjectUtil.isFacetedGradleBundleProject(project)) {
 						return new FacetedGradleBundleProject(project);
 					}

--- a/tools/plugins/com.liferay.ide.gradle.core/src/com/liferay/ide/gradle/core/GradleUtil.java
+++ b/tools/plugins/com.liferay.ide.gradle.core/src/com/liferay/ide/gradle/core/GradleUtil.java
@@ -17,6 +17,7 @@ package com.liferay.ide.gradle.core;
 import com.google.common.base.Optional;
 
 import com.gradleware.tooling.toolingutils.binding.Validator;
+
 import com.liferay.ide.core.util.FileUtil;
 
 import java.io.File;

--- a/tools/plugins/com.liferay.ide.gradle.core/src/com/liferay/ide/gradle/core/LiferayGradleProject.java
+++ b/tools/plugins/com.liferay.ide.gradle.core/src/com/liferay/ide/gradle/core/LiferayGradleProject.java
@@ -190,6 +190,7 @@ public class LiferayGradleProject extends BaseLiferayProject implements IBundleP
 					for (File outputFile : outputFiles) {
 						if (outputFile.getName().endsWith(".war")) {
 							bundleFile = outputFile;
+
 							break;
 						}
 					}

--- a/tools/plugins/com.liferay.ide.gradle.core/src/com/liferay/ide/gradle/core/LiferayGradleWorkspaceProject.java
+++ b/tools/plugins/com.liferay.ide.gradle.core/src/com/liferay/ide/gradle/core/LiferayGradleWorkspaceProject.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.ide.gradle.core;
+
+import com.liferay.ide.core.util.FileUtil;
+import com.liferay.ide.core.util.PropertiesUtil;
+import com.liferay.ide.project.core.IProjectBuilder;
+import com.liferay.ide.project.core.IWorkspaceProjectBuilder;
+import com.liferay.ide.project.core.LiferayWorkspaceProject;
+
+import java.io.File;
+
+import java.util.Properties;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.IPath;
+
+/**
+ * @author Andy Wu
+ * @author Simon Jiang
+ */
+public class LiferayGradleWorkspaceProject extends LiferayWorkspaceProject {
+
+	public LiferayGradleWorkspaceProject(IProject project) {
+		super(project);
+	}
+
+	@Override
+	public <T> T adapt(Class<T> adapterType) {
+		if (IProjectBuilder.class.equals(adapterType) || IWorkspaceProjectBuilder.class.equals(adapterType)) {
+			IProjectBuilder projectBuilder = new GradleProjectBuilder(getProject());
+
+			return adapterType.cast(projectBuilder);
+		}
+
+		return super.adapt(adapterType);
+	}
+
+	@Override
+	public String getProperty(String key, String defaultValue) {
+		if (project == null) {
+			return null;
+		}
+
+		IPath projectLocation = project.getLocation();
+
+		File gradleProperties = new File(projectLocation.toFile(), "gradle.properties");
+
+		String retVal = null;
+
+		if (FileUtil.exists(gradleProperties)) {
+			Properties properties = PropertiesUtil.loadProperties(gradleProperties);
+
+			retVal = properties.getProperty(key, defaultValue);
+		}
+
+		return retVal;
+	}
+
+}

--- a/tools/plugins/com.liferay.ide.gradle.core/src/com/liferay/ide/gradle/core/parser/GradleDependencyUpdater.java
+++ b/tools/plugins/com.liferay.ide.gradle.core/src/com/liferay/ide/gradle/core/parser/GradleDependencyUpdater.java
@@ -14,20 +14,23 @@
 
 package com.liferay.ide.gradle.core.parser;
 
+import com.liferay.ide.core.util.CoreUtil;
+
 import java.io.File;
 import java.io.IOException;
+
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+
 import java.util.List;
 
 import org.apache.commons.io.FileUtils;
+
 import org.codehaus.groovy.ast.ASTNode;
 import org.codehaus.groovy.ast.GroovyCodeVisitor;
 import org.codehaus.groovy.ast.builder.AstBuilder;
 import org.codehaus.groovy.control.MultipleCompilationErrorsException;
-
-import com.liferay.ide.core.util.CoreUtil;
 
 /**
  * @author Lovett Li

--- a/tools/plugins/com.liferay.ide.project.core/META-INF/MANIFEST.MF
+++ b/tools/plugins/com.liferay.ide.project.core/META-INF/MANIFEST.MF
@@ -38,7 +38,9 @@ Require-Bundle: org.eclipse.wst.common.project.facet.core;visibility:=reexport,
  org.apache.felix.gogo.runtime,
  org.apache.ant,
  biz.aQute.bndlib;bundle-version="[4,5)",
- com.liferay.ide.upgrade.core
+ com.liferay.ide.upgrade.core,
+ org.eclipse.ltk.ui.refactoring,
+ org.eclipse.ltk.core.refactoring
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Export-Package: com.liferay.ide.project.core,

--- a/tools/plugins/com.liferay.ide.project.core/plugin.xml
+++ b/tools/plugins/com.liferay.ide.project.core/plugin.xml
@@ -612,6 +612,13 @@
 			type="java.lang.Object"
 		>
 		</propertyTester>
+		<propertyTester
+		    class="com.liferay.ide.project.core.workspace.LiferayWorkspaceProjectPropertyTester"
+		    id="com.liferay.ide.project.core.isLiferayWorkspaceProject"
+		    namespace="com.liferay.ide.project.core"
+		    properties="isLiferayWorkspaceProject"
+		    type="org.eclipse.core.resources.IProject">
+		</propertyTester>
 	</extension>
 
 	<extension
@@ -849,5 +856,21 @@
 			shortName="MVCPortlet"
 		>
 		</liferayComponentTemplate>
+	</extension>
+	<extension
+	     point="org.eclipse.ltk.core.refactoring.deleteParticipants">
+		<deleteParticipant
+	    	class="com.liferay.ide.project.core.workspace.LiferayWorkspaceProjectDeleteParticipant"
+	    	id="com.liferay.ide.project.core.workspace.liferayWorkspaceProjectDeleteParticipant"
+	    	name="liferayWorkspaceProjectDeleteParticipant">
+			<enablement>
+				<adapt
+		      		type="org.eclipse.core.resources.IProject">
+					<test
+		   				property="com.liferay.ide.project.core.isLiferayWorkspaceProject">
+		 			</test>
+				</adapt>
+			</enablement>
+		</deleteParticipant>
 	</extension>
 </plugin>

--- a/tools/plugins/com.liferay.ide.project.core/src/com/liferay/ide/project/core/LiferayWorkspaceProject.java
+++ b/tools/plugins/com.liferay.ide.project.core/src/com/liferay/ide/project/core/LiferayWorkspaceProject.java
@@ -12,14 +12,12 @@
  * details.
  */
 
-package com.liferay.ide.gradle.core;
+package com.liferay.ide.project.core;
 
 import com.liferay.ide.core.BaseLiferayProject;
 import com.liferay.ide.core.ILiferayPortal;
 import com.liferay.ide.core.IWorkspaceProject;
 import com.liferay.ide.core.util.FileUtil;
-import com.liferay.ide.project.core.IProjectBuilder;
-import com.liferay.ide.project.core.IWorkspaceProjectBuilder;
 import com.liferay.ide.server.core.LiferayServerCore;
 import com.liferay.ide.server.core.portal.PortalBundle;
 
@@ -31,7 +29,7 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.IPath;
 
 /**
- * @author Andy Wu
+ * @author Simon Jiang
  */
 public class LiferayWorkspaceProject extends BaseLiferayProject implements IWorkspaceProject {
 
@@ -56,12 +54,6 @@ public class LiferayWorkspaceProject extends BaseLiferayProject implements IWork
 			}
 		}
 
-		if (IProjectBuilder.class.equals(adapterType) || IWorkspaceProjectBuilder.class.equals(adapterType)) {
-			IProjectBuilder projectBuilder = new GradleProjectBuilder(getProject());
-
-			return adapterType.cast(projectBuilder);
-		}
-
 		return super.adapt(adapterType);
 	}
 
@@ -79,6 +71,4 @@ public class LiferayWorkspaceProject extends BaseLiferayProject implements IWork
 	public List<IPath> getTargetPlatformArtifacts() {
 		return Collections.emptyList();
 	}
-
-
 }

--- a/tools/plugins/com.liferay.ide.project.core/src/com/liferay/ide/project/core/workspace/LiferayWorkspaceProjectDeleteParticipant.java
+++ b/tools/plugins/com.liferay.ide.project.core/src/com/liferay/ide/project/core/workspace/LiferayWorkspaceProjectDeleteParticipant.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.ide.project.core.workspace;
+
+import com.liferay.ide.core.util.FileUtil;
+import com.liferay.ide.project.core.ProjectCore;
+import com.liferay.ide.project.core.util.LiferayWorkspaceUtil;
+
+import java.util.stream.Stream;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
+import org.eclipse.ltk.core.refactoring.Change;
+import org.eclipse.ltk.core.refactoring.CompositeChange;
+import org.eclipse.ltk.core.refactoring.RefactoringStatus;
+import org.eclipse.ltk.core.refactoring.participants.CheckConditionsContext;
+import org.eclipse.ltk.core.refactoring.participants.DeleteParticipant;
+import org.eclipse.wst.server.core.IRuntime;
+import org.eclipse.wst.server.core.IServer;
+import org.eclipse.wst.server.core.ServerCore;
+
+/**
+ * @author Simon Jiang
+ */
+
+public class LiferayWorkspaceProjectDeleteParticipant extends DeleteParticipant {
+
+	public LiferayWorkspaceProjectDeleteParticipant() {
+	}
+
+	@Override
+	protected boolean initialize(Object element) {
+
+		if(!(element instanceof IProject)) {
+			return false;
+		}
+
+		_workspaceProject = (IProject) element;
+		return true;
+	}
+
+	@Override
+	public String getName() {
+		return _MODS_FROM_WORKSPACE_PROJECT;
+	}
+
+	@Override
+	public RefactoringStatus checkConditions(IProgressMonitor pm,
+			CheckConditionsContext context) throws OperationCanceledException {
+		return new RefactoringStatus();
+	}
+
+	@Override
+	public Change createChange(IProgressMonitor pm) throws CoreException,
+			OperationCanceledException {
+		CompositeChange change = new CompositeChange(getName());
+
+		if ((_workspaceProject == null) || FileUtil.notExists(_workspaceProject)) {
+			return change;
+		}
+
+		IPath bundlesLocation = LiferayWorkspaceUtil.getHomeLocation(_workspaceProject);
+
+		if ((bundlesLocation == null) || FileUtil.notExists(bundlesLocation)) {
+			return change;
+		}
+
+		IServer[] servers = ServerCore.getServers();
+
+		Stream<IServer> serverStream = Stream.of(servers);
+
+		serverStream.filter(server -> server != null)
+		.filter(server -> server.getRuntime().getLocation().equals(bundlesLocation))
+		.forEach(server -> change.add(new RemoveLiferayWorkspaceBundleServerRuntimeChange(server)));
+
+		return change;
+	}	
+
+	public class RemoveLiferayWorkspaceBundleServerRuntimeChange extends Change {
+		private IServer _server;
+		public RemoveLiferayWorkspaceBundleServerRuntimeChange(IServer server) {
+			_server = server;
+		}
+
+		@Override
+		public String getName() {
+			return _MODS_FROM_WORKSPACE_PROJECT;
+		}
+
+		@Override
+		public void initializeValidationData(IProgressMonitor pm) {
+		}
+
+		@Override
+		public RefactoringStatus isValid(IProgressMonitor pm)
+				throws CoreException, OperationCanceledException {
+			return new RefactoringStatus();
+		}
+
+		@Override
+		public Change perform(IProgressMonitor pm) throws CoreException {
+			try {
+				IRuntime runtime = _server.getRuntime();
+				_server.delete();
+
+				if (runtime != null) {
+					runtime.delete();
+				}
+			}
+			catch(Exception e) {
+				ProjectCore.logError("Failed to delete server " + _server.getName(), e);
+			}
+			return null;
+		}
+
+		@Override
+		public Object getModifiedElement() {
+			return _server;
+		}
+	}
+
+	private IProject _workspaceProject;
+	private static final String _MODS_FROM_WORKSPACE_PROJECT = "Liferay Workpsace Project Bundle's Runtime Cleanup";
+}

--- a/tools/plugins/com.liferay.ide.project.core/src/com/liferay/ide/project/core/workspace/LiferayWorkspaceProjectPropertyTester.java
+++ b/tools/plugins/com.liferay.ide.project.core/src/com/liferay/ide/project/core/workspace/LiferayWorkspaceProjectPropertyTester.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.ide.project.core.workspace;
+
+import com.liferay.ide.core.IWorkspaceProject;
+import com.liferay.ide.core.LiferayCore;
+
+import org.eclipse.core.expressions.PropertyTester;
+import org.eclipse.core.resources.IProject;
+
+/**
+ * @author Simon Jiang
+ */
+
+public class LiferayWorkspaceProjectPropertyTester extends PropertyTester {
+
+	@Override
+	public boolean test(
+		Object receiver, String property, Object[] args, Object expectedValue) {
+		if (receiver instanceof IProject) {
+			final IProject project = (IProject)receiver;
+
+			IWorkspaceProject workspaceProject = LiferayCore.create(IWorkspaceProject.class, project);
+
+			if ( workspaceProject != null) {
+				return true;
+			}
+		}
+
+		return false;	
+	}
+
+}


### PR DESCRIPTION
1.) The workspace project delete action need to identify the project type, we have defined liferayWorkpsace project before and the delete action need to check the project type for maven liferay workspace project.
2.) We will support multiple liferay workspace project in futture, so I add the LiferayMavenWorkspace project to complete related functions.
