### PR TITLE
IDE-4086 Avoid use CoreUtil.getClasspathEntries throw NullPointException

### DIFF
--- a/tools/plugins/com.liferay.ide.core/src/com/liferay/ide/core/util/CoreUtil.java
+++ b/tools/plugins/com.liferay.ide.core/src/com/liferay/ide/core/util/CoreUtil.java
@@ -208,7 +208,7 @@ public class CoreUtil {
 
 	public static IClasspathEntry[] getClasspathEntries(IProject project) {
 		if (project == null) {
-			return null;
+			return new IClasspathEntry[0];
 		}
 
 		IJavaProject javaProject = JavaCore.create(project);
@@ -219,7 +219,7 @@ public class CoreUtil {
 		catch (JavaModelException jme) {
 		}
 
-		return null;
+		return new IClasspathEntry[0];
 	}
 
 	public static IProject[] getClasspathProjects(IProject project) {


### PR DESCRIPTION
IDE-4086 Avoid use CoreUtil.getClasspathEntries throw NullPointException