### PR TITLE
IDE-4273 Fix the NullPointException when move watching projects into workspace project instance and there is no workspace exist

### DIFF
--- a/tools/plugins/com.liferay.ide.gradle.ui/src/com/liferay/ide/gradle/ui/navigator/workspace/LiferayWorkspaceServerLabelProvider.java
+++ b/tools/plugins/com.liferay.ide.gradle.ui/src/com/liferay/ide/gradle/ui/navigator/workspace/LiferayWorkspaceServerLabelProvider.java
@@ -45,11 +45,13 @@ public class LiferayWorkspaceServerLabelProvider extends LabelProvider implement
 
 		IProject project = (IProject)element;
 
-		if (ListUtil.contains(iWorkspaceProject.watching(), project)) {
-			decoration.addSuffix(" [watching]");
-		}
-		else {
-			decoration.addSuffix("");
+		if (iWorkspaceProject != null) {
+			if (ListUtil.contains(iWorkspaceProject.watching(), project)) {
+				decoration.addSuffix(" [watching]");
+			}
+			else {
+				decoration.addSuffix("");
+			}
 		}
 	}
 


### PR DESCRIPTION
Hi @jtydhr88 

I can't reproduce this issue anymore, but I found a NullpointException happened when move watching projects into workspace project instance and there is no workspace exist. I guess maybe it is this exception makes the Builderservice button doesn't work.

Br,
Seiphon