### PR TITLE
IDE-4317 give a fixed name for gradle watch launch configuration

### DIFF
--- a/tools/plugins/com.liferay.ide.gradle.core/src/com/liferay/ide/gradle/core/LiferayGradleWorkspaceProject.java
+++ b/tools/plugins/com.liferay.ide.gradle.core/src/com/liferay/ide/gradle/core/LiferayGradleWorkspaceProject.java
@@ -236,7 +236,8 @@ public class LiferayGradleWorkspaceProject extends LiferayWorkspaceProject {
 
 					String[] args = {"--continuous", "--continue"};
 
-					GradleUtil.runGradleTask(getProject(), tasks.toArray(new String[0]), args, monitor);
+					GradleUtil.runGradleTask(
+						getProject(), tasks.toArray(new String[0]), args, "liferay-watch", monitor);
 				}
 				catch (Exception e) {
 					return GradleCore.createErrorStatus(


### PR DESCRIPTION
a long task name will cause error during buildship persisting configuration