### PR TITLE
IDE-4328 fix the repeated backslash issue for regular expression

### DIFF
--- a/tools/plugins/com.liferay.ide.upgrade.core/src/com/liferay/blade/upgrade/liferay71/apichanges/LiferayVersionsProperties71.java
+++ b/tools/plugins/com.liferay.ide.upgrade.core/src/com/liferay/blade/upgrade/liferay71/apichanges/LiferayVersionsProperties71.java
@@ -32,7 +32,7 @@ import org.osgi.service.component.annotations.Component;
 public class LiferayVersionsProperties71 extends BaseLiferayVersionsProperties {
 
 	public LiferayVersionsProperties71() {
-		super(".*7\\\\.[1-9]\\\\.[0-9].*", "7.1.0+");
+		super(".*7\\.[1-9]\\.[0-9].*", "7.1.0+");
 	}
 
 }


### PR DESCRIPTION
Hi @jtydhr88 

This issue caused by the repeated backslash for regular expression.

Br
Seiphon