### PR TITLE
IDE-4329 Should not find breaking changes in build folder

### DIFF
--- a/tools/plugins/com.liferay.ide.project.ui/src/com/liferay/ide/project/ui/migration/MigrationContentProvider.java
+++ b/tools/plugins/com.liferay.ide.project.ui/src/com/liferay/ide/project/ui/migration/MigrationContentProvider.java
@@ -113,6 +113,8 @@ public class MigrationContentProvider implements ITreeContentProvider {
 					MigrationProblemsContainer.class);
 
 				if (container != null) {
+					MigrationUtil.removeProblemsInBuildForlder(container);
+
 					_problems.add(container);
 				}
 			}

--- a/tools/plugins/com.liferay.ide.project.ui/src/com/liferay/ide/project/ui/migration/MigrationUtil.java
+++ b/tools/plugins/com.liferay.ide.project.ui/src/com/liferay/ide/project/ui/migration/MigrationUtil.java
@@ -35,6 +35,8 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
@@ -414,6 +416,28 @@ public class MigrationUtil {
 		MigrationProblemsContainer container = getMigrationProblemsContainer();
 
 		return _removeProblemFromMigrationContainer(resource.getName(), container);
+	}
+
+	public static void removeProblemsInBuildForlder(MigrationProblemsContainer container) {
+		MigrationProblems[] projectProblems = container.getProblemsArray();
+
+		for (MigrationProblems migrationProblems : projectProblems) {
+			FileProblems[] fileProblems = migrationProblems.getProblems();
+
+			Stream<FileProblems> fileProblemsStream = Arrays.stream(fileProblems);
+
+			List<FileProblems> fileProblemsList = fileProblemsStream.filter(
+				fileProblem -> {
+					String filePath = fileProblem.file.toString();
+
+					return !filePath.contains("/build/");
+				}
+			).collect(
+				Collectors.toList()
+			);
+
+			migrationProblems.setProblems(fileProblemsList.toArray(new FileProblems[0]));
+		}
 	}
 
 	public static void updateMigrationProblemToStore(Problem problem) {

--- a/tools/plugins/com.liferay.ide.project.ui/src/com/liferay/ide/project/ui/upgrade/animated/FindBreakingChangesPage.java
+++ b/tools/plugins/com.liferay.ide.project.ui/src/com/liferay/ide/project/ui/upgrade/animated/FindBreakingChangesPage.java
@@ -459,6 +459,8 @@ public class FindBreakingChangesPage extends Page implements IDoubleClickListene
 			if (container != null) {
 				problems = new ArrayList<>();
 
+				MigrationUtil.removeProblemsInBuildForlder(container);
+
 				problems.add(container);
 			}
 		}


### PR DESCRIPTION
Hi @jtydhr88

For this issue, my solution is made the problems in build folder won't be displayed.

I referred the description from https://github.com/liferay/liferay-portal/blob/master/modules/util/source-formatter/documentation/chaining.markdown , I found the chain after stream is not allowed. 

`
Stream<User> usersStream = users.stream();

usersStream.filter(
    relations -> isFieldIncluded(types, relation.getName())
).filter(
    relation -> representorManager.isPresent(relation.getType())
).filter(
    relation -> {
        Creator creator = relation.getCreator();

        Optional<V> relationResource = creator.apply(resource);
    }
);
`

Br,
Seiphon