### PR TITLE
IDE-4189 Redeploy action doesn't work

### DIFF
--- a/tools/plugins/com.liferay.ide.server.ui/src/com/liferay/ide/server/ui/action/AbstractServerRunningAction.java
+++ b/tools/plugins/com.liferay.ide.server.ui/src/com/liferay/ide/server/ui/action/AbstractServerRunningAction.java
@@ -89,9 +89,9 @@ public abstract class AbstractServerRunningAction implements IObjectActionDelega
 				else if (obj instanceof IServerModule) {
 					selectedModule = (IServerModule)obj;
 
-					IServer server = selectedModule.getServer();
+					selectedServer = selectedModule.getServer();
 
-					action.setEnabled((server.getServerState() & getRequiredServerState()) > 0);
+					action.setEnabled((selectedServer.getServerState() & getRequiredServerState()) > 0);
 				}
 			}
 		}

--- a/tools/plugins/com.liferay.ide.server.ui/src/com/liferay/ide/server/ui/action/RedeployAction.java
+++ b/tools/plugins/com.liferay.ide.server.ui/src/com/liferay/ide/server/ui/action/RedeployAction.java
@@ -81,6 +81,8 @@ public class RedeployAction extends AbstractServerRunningAction {
 
 	@Override
 	public void selectionChanged(IAction action, ISelection selection) {
+		super.selectionChanged(action, selection);
+
 		boolean validServerState = true;
 
 		if (!selection.isEmpty()) {


### PR DESCRIPTION
Hi @jtydhr88 

For this issue, the reason is the parameter selectedServer always be null, so I give it a value when executing the selectinChanged() method.

Br,
Seiphon