### PR TITLE
IDE-4258 Add default value for isdxp and bundleversion

### DIFF
--- a/build/installers/liferay-project-sdk/liferay-project-sdk.xml
+++ b/build/installers/liferay-project-sdk/liferay-project-sdk.xml
@@ -543,7 +543,7 @@
                     <width>30</width>
                 </directoryParameter>
                 <labelParameter>
-                    <name>skiplsws</name>
+                    <name>skiplrws</name>
                     <title>skipLrws</title>
                     <description>Don't initialize Liferay Workspace directory</description>
                     <explanation></explanation>

--- a/build/installers/liferay-project-sdk/liferay-project-sdk.xml
+++ b/build/installers/liferay-project-sdk/liferay-project-sdk.xml
@@ -580,7 +580,7 @@
             <description></description>
             <explanation>When initializing a new Liferay Workspace, Liferay Customers can use Liferay DXP Bundle. Community members should choose Liferay Portal Community Edition.</explanation>
             <value></value>
-            <default></default>
+            <default>ce</default>
             <parameterList>
                 <labelParameter>
                     <name>dxp</name>
@@ -611,7 +611,7 @@
             <description></description>
             <explanation>Specify initialized liferay bundle version.</explanation>
             <value></value>
-            <default></default>
+            <default>7_1</default>
             <parameterList>
                 <labelParameter>
                     <name>7_0</name>


### PR DESCRIPTION
Hi @jtydhr88 

Adding default value for isdxp and bundleversion is necessary, and there is a requirement for default value of bundleversion. [IDE-4383](https://issues.liferay.com/browse/IDE-4383)

Br,
Seiphon