### PR TITLE
IDE-4407 Upgrade tool Descriptor

### DIFF
--- a/tools/plugins/com.liferay.ide.upgrade.core/META-INF/MANIFEST.MF
+++ b/tools/plugins/com.liferay.ide.upgrade.core/META-INF/MANIFEST.MF
@@ -145,6 +145,8 @@ Service-Component: OSGI-INF/com.liferay.blade.eclipse.provider.CUCacheWTP.xml,
  OSGI-INF/com.liferay.blade.upgrade.liferay71.apichanges.DecoupledImplementingBaseURLClasses.xml,
  OSGI-INF/com.liferay.blade.upgrade.liferay71.apichanges.RemovedJavaScriptMinificationProperties.xml,
  OSGI-INF/com.liferay.blade.upgrade.liferay71.apichanges.LiferayVersionsProperties71.xml,
- OSGI-INF/com.liferay.blade.upgrade.liferay70.apichanges.LiferayVersionsProperties70.xml
+ OSGI-INF/com.liferay.blade.upgrade.liferay70.apichanges.LiferayVersionsProperties70.xml,
+ OSGI-INF/com.liferay.blade.upgrade.liferay70.descriptors.LiferayDescriptorVersion70.xml,
+ OSGI-INF/com.liferay.blade.upgrade.liferay71.descriptors.LiferayDescriptorVersion71.xml
 Bundle-ClassPath: .,
  libs/com.liferay.markdown.parser.jar

--- a/tools/plugins/com.liferay.ide.upgrade.core/OSGI-INF/com.liferay.blade.upgrade.liferay70.descriptors.LiferayDescriptorVersion70.xml
+++ b/tools/plugins/com.liferay.ide.upgrade.core/OSGI-INF/com.liferay.blade.upgrade.liferay70.descriptors.LiferayDescriptorVersion70.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" name="com.liferay.blade.upgrade.liferay70.descriptors.LiferayDescriptorVersion70">
+   <property name="file.extensions" value="xml"/>
+   <property name="problem.title" value="Descriptor XML DTD Versions Changes"/>
+   <property name="problem.summary" value="The descriptor XML DTD versions should be matched with version 7.0."/>
+   <property name="problem.section" value="#descriptor-XML-DTD-version"/>
+   <property name="auto.correct" value="descriptor"/>
+   <property name="implName" value="LiferayDescriptorVersion"/>
+   <property name="version" value="7.0"/>
+   <service>
+      <provide interface="com.liferay.blade.api.AutoMigrator"/>
+      <provide interface="com.liferay.blade.api.FileMigrator"/>
+   </service>
+   <implementation class="com.liferay.blade.upgrade.liferay70.descriptors.LiferayDescriptorVersion70"/>
+</scr:component>

--- a/tools/plugins/com.liferay.ide.upgrade.core/OSGI-INF/com.liferay.blade.upgrade.liferay71.descriptors.LiferayDescriptorVersion71.xml
+++ b/tools/plugins/com.liferay.ide.upgrade.core/OSGI-INF/com.liferay.blade.upgrade.liferay71.descriptors.LiferayDescriptorVersion71.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" name="com.liferay.blade.upgrade.liferay71.descriptors.LiferayDescriptorVersion71">
+   <property name="file.extensions" value="xml"/>
+   <property name="problem.title" value="Descriptor XML DTD Versions Changes"/>
+   <property name="problem.summary" value="The descriptor XML DTD versions should be matched with version 7.1."/>
+   <property name="problem.section" value="#descriptor-XML-DTD-version"/>
+   <property name="auto.correct" value="descriptor"/>
+   <property name="implName" value="LiferayDescriptorVersion"/>
+   <property name="version" value="7.1"/>
+   <service>
+      <provide interface="com.liferay.blade.api.AutoMigrator"/>
+      <provide interface="com.liferay.blade.api.FileMigrator"/>
+   </service>
+   <implementation class="com.liferay.blade.upgrade.liferay71.descriptors.LiferayDescriptorVersion71"/>
+</scr:component>

--- a/tools/plugins/com.liferay.ide.upgrade.core/src/com/liferay/blade/eclipse/provider/ProjectMigrationService.java
+++ b/tools/plugins/com.liferay.ide.upgrade.core/src/com/liferay/blade/eclipse/provider/ProjectMigrationService.java
@@ -284,7 +284,7 @@ public class ProjectMigrationService implements Migration {
 					migratorStream.map(
 						_context::getService
 					).parallel(
-					).forEach(
+					).forEachOrdered(
 						fm -> {
 							List<Problem> fileProlbems = fm.analyze(file);
 

--- a/tools/plugins/com.liferay.ide.upgrade.core/src/com/liferay/blade/upgrade/liferay70/apichanges/BaseLiferayDescriptorVersion.java
+++ b/tools/plugins/com.liferay.ide.upgrade.core/src/com/liferay/blade/upgrade/liferay70/apichanges/BaseLiferayDescriptorVersion.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.blade.upgrade.liferay70.apichanges;
+
+import com.liferay.blade.api.AutoMigrateException;
+import com.liferay.blade.api.AutoMigrator;
+import com.liferay.blade.api.Problem;
+import com.liferay.blade.api.SearchResult;
+import com.liferay.blade.api.XMLFile;
+import com.liferay.blade.upgrade.XMLFileMigrator;
+
+import java.io.File;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.wst.sse.core.StructuredModelManager;
+import org.eclipse.wst.sse.core.internal.provisional.IModelManager;
+import org.eclipse.wst.xml.core.internal.provisional.document.IDOMDocument;
+import org.eclipse.wst.xml.core.internal.provisional.document.IDOMDocumentType;
+import org.eclipse.wst.xml.core.internal.provisional.document.IDOMModel;
+
+/**
+ * @author Seiphon Wang
+ */
+@SuppressWarnings("restriction")
+public abstract class BaseLiferayDescriptorVersion extends XMLFileMigrator implements AutoMigrator {
+
+	public BaseLiferayDescriptorVersion(Pattern publicIDPattern, String version) {
+		_idPattern = publicIDPattern;
+		_version = version;
+	}
+
+	@Override
+	public int correctProblems(File file, List<Problem> problems) throws AutoMigrateException {
+		int problemsCorrected = 0;
+
+		try {
+			IFile xmlFile = getXmlFile(file);
+
+			IModelManager modelManager = StructuredModelManager.getModelManager();
+
+			IDOMModel domModel = (IDOMModel)modelManager.getModelForEdit(xmlFile);
+
+			IDOMDocument domDocument = domModel.getDocument();
+
+			IDOMDocumentType domDocumentType = (IDOMDocumentType)domDocument.getDoctype();
+
+			if (domDocumentType != null) {
+				String publicId = domDocumentType.getPublicId();
+
+				String newPublicId = _getNewDoctTypeSetting(publicId, _version, _publicPattern);
+
+				domDocumentType.setPublicId(newPublicId);
+
+				String systemId = domDocumentType.getSystemId();
+
+				String newSystemId = _getNewDoctTypeSetting(systemId, _version.replaceAll("\\.", "_"), _systemPattern);
+
+				domDocumentType.setSystemId(newSystemId);
+
+				problemsCorrected++;
+			}
+
+			domModel.save();
+		}
+		catch (Exception e) {
+		}
+
+		return problemsCorrected;
+	}
+
+	@Override
+	protected List<SearchResult> searchFile(File file, XMLFile xmlFileChecker) {
+		List<SearchResult> results = new ArrayList<>();
+
+		for (String liferayDtdName : _liferayDtdNames) {
+			results.add(xmlFileChecker.findDocumentTypeDeclaration(liferayDtdName, _idPattern));
+		}
+
+		return results;
+	}
+
+	private String _getNewDoctTypeSetting(String doctypeSetting, String newValue, Pattern pattern) {
+		String newDoctTypeSetting = null;
+
+		Matcher m = pattern.matcher(doctypeSetting);
+
+		if (m.find()) {
+			String oldVersionString = m.group(m.groupCount());
+
+			newDoctTypeSetting = doctypeSetting.replace(oldVersionString, newValue);
+		}
+
+		return newDoctTypeSetting;
+	}
+
+	private static final Pattern _publicPattern = Pattern.compile(
+		"-\\//(?:[A-z]+)\\//(?:[A-z]+)[\\s+(?:[A-z0-9_]*)]*\\s+(\\d\\.\\d\\.\\d)\\//(?:[A-z]+)",
+		Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+	private static final Pattern _systemPattern = Pattern.compile(
+		"^http://www.liferay.com/dtd/[-A-Za-z0-9+&@#/%?=~_()]*(\\d_\\d_\\d).dtd",
+		Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+
+	private Pattern _idPattern;
+	private String[] _liferayDtdNames =
+		{"liferay-portlet-app", "display", "service-builder", "hook", "layout-templates", "look-and-feel"};
+	private String _version;
+
+}

--- a/tools/plugins/com.liferay.ide.upgrade.core/src/com/liferay/blade/upgrade/liferay70/descriptors/LiferayDescriptorVersion70.java
+++ b/tools/plugins/com.liferay.ide.upgrade.core/src/com/liferay/blade/upgrade/liferay70/descriptors/LiferayDescriptorVersion70.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.blade.upgrade.liferay70.descriptors;
+
+import com.liferay.blade.api.AutoMigrator;
+import com.liferay.blade.api.FileMigrator;
+import com.liferay.blade.upgrade.liferay70.apichanges.BaseLiferayDescriptorVersion;
+
+import java.util.regex.Pattern;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Seiphon Wang
+ */
+@Component(property = {
+	"file.extensions=xml", "problem.title=Descriptor XML DTD Versions Changes",
+	"problem.summary=The descriptor XML DTD versions should be matched with version 7.0.",
+	"problem.section=#descriptor-XML-DTD-version", "auto.correct=descriptor", "implName=LiferayDescriptorVersion",
+	"version=7.0"
+},
+	service = {AutoMigrator.class, FileMigrator.class})
+public class LiferayDescriptorVersion70 extends BaseLiferayDescriptorVersion {
+
+	public LiferayDescriptorVersion70() {
+		super(_publicIDPattern, "7.0.0");
+	}
+
+	private static final Pattern _publicIDPattern = Pattern.compile(
+		"-\\//(?:[A-z]+)\\//(?:[A-z]+)[\\s+(?:[A-z0-9_]*)]*\\s+(7\\.[0-9]\\.[0-9])\\//(?:[A-z]+)",
+		Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+
+}

--- a/tools/plugins/com.liferay.ide.upgrade.core/src/com/liferay/blade/upgrade/liferay71/descriptors/LiferayDescriptorVersion71.java
+++ b/tools/plugins/com.liferay.ide.upgrade.core/src/com/liferay/blade/upgrade/liferay71/descriptors/LiferayDescriptorVersion71.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.blade.upgrade.liferay71.descriptors;
+
+import com.liferay.blade.api.AutoMigrator;
+import com.liferay.blade.api.FileMigrator;
+import com.liferay.blade.upgrade.liferay70.apichanges.BaseLiferayDescriptorVersion;
+
+import java.util.regex.Pattern;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Seiphon Wang
+ */
+@Component(property = {
+	"file.extensions=xml", "problem.title=Descriptor XML DTD Versions Changes",
+	"problem.summary=The descriptor XML DTD versions should be matched with version 7.1.",
+	"problem.section=#descriptor-XML-DTD-version", "auto.correct=descriptor", "implName=LiferayDescriptorVersion",
+	"version=7.1"
+},
+	service = {AutoMigrator.class, FileMigrator.class})
+public class LiferayDescriptorVersion71 extends BaseLiferayDescriptorVersion {
+
+	public LiferayDescriptorVersion71() {
+		super(_publicPattern, "7.1.0");
+	}
+
+	private static final Pattern _publicPattern = Pattern.compile(
+		"-\\//(?:[A-z]+)\\//(?:[A-z]+)[\\s+(?:[A-z0-9_]*)]*\\s+(7\\.[1-9]\\.[0-9])\\//(?:[A-z]+)",
+		Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+
+}

--- a/tools/tests/com.liferay.ide.upgrade.core.tests/src/com/liferay/blade/test/InitJSPParseTest.java
+++ b/tools/tests/com.liferay.ide.upgrade.core.tests/src/com/liferay/blade/test/InitJSPParseTest.java
@@ -43,7 +43,7 @@ public class InitJSPParseTest {
 
 		List<Problem> problems = m.findProblems(new File("jsptests/jukebox-portlet/"), new NullProgressMonitor());
 
-		Assert.assertEquals("", 329, problems.size());
+		Assert.assertEquals("", 333, problems.size());
 
 		boolean found = false;
 

--- a/tools/tests/com.liferay.ide.upgrade.core.tests/src/com/liferay/blade/test/InitJSPParseTest.java
+++ b/tools/tests/com.liferay.ide.upgrade.core.tests/src/com/liferay/blade/test/InitJSPParseTest.java
@@ -19,7 +19,7 @@ import com.liferay.blade.api.Problem;
 import com.liferay.blade.util.NullProgressMonitor;
 
 import java.io.File;
-
+import java.util.Arrays;
 import java.util.List;
 
 import org.junit.Assert;
@@ -41,9 +41,11 @@ public class InitJSPParseTest {
 
 		Migration m = _context.getService(sr);
 
-		List<Problem> problems = m.findProblems(new File("jsptests/jukebox-portlet/"), new NullProgressMonitor());
+		List<String> versions = Arrays.asList(new String[] {"7.0", "7.1"});
 
-		Assert.assertEquals("", 333, problems.size());
+		List<Problem> problems = m.findProblems(new File("jsptests/jukebox-portlet/"), versions, new NullProgressMonitor());
+
+		Assert.assertEquals("", 332, problems.size());
 
 		boolean found = false;
 

--- a/tools/tests/com.liferay.ide.upgrade.core.tests/src/com/liferay/blade/test/apichanges/APITestBase.java
+++ b/tools/tests/com.liferay.ide.upgrade.core.tests/src/com/liferay/blade/test/apichanges/APITestBase.java
@@ -39,7 +39,7 @@ public abstract class APITestBase {
 
 	@Before
 	public void beforeTest() throws Exception {
-		Filter filter = context.createFilter("(implName=" + getImplClassName() + ")");
+		Filter filter = getFilter();
 
 		ServiceTracker<FileMigrator, FileMigrator> fileMigratorTracker = new ServiceTracker<>(context, filter, null);
 
@@ -54,6 +54,10 @@ public abstract class APITestBase {
 
 	public int getExpectedNumber() {
 		return 1;
+	}
+
+	protected Filter getFilter() throws Exception {
+		return context.createFilter("(implName=" + getImplClassName() + ")");
 	}
 
 	public abstract String getImplClassName();

--- a/tools/tests/com.liferay.ide.upgrade.core.tests/src/com/liferay/blade/test/apichanges/APIVersionSupportTestBase.java
+++ b/tools/tests/com.liferay.ide.upgrade.core.tests/src/com/liferay/blade/test/apichanges/APIVersionSupportTestBase.java
@@ -12,18 +12,20 @@
  * details.
  */
 
-package com.liferay.blade.api;
+package com.liferay.blade.test.apichanges;
 
-import java.util.Collection;
-import java.util.regex.Pattern;
+import org.osgi.framework.Filter;
 
 /**
- * @author Gregory Amerson
+ * @author Seiphon Wang
  */
-public interface XMLFile extends SourceFile {
+public abstract class APIVersionSupportTestBase extends APITestBase {
 
-	public SearchResult findDocumentTypeDeclaration(String name, Pattern idPattern);
+	@Override
+	protected Filter getFilter() throws Exception {
+		return context.createFilter("(&(implName=" + getImplClassName() + ")(version=" + getVersion() + "))");
+	}
 
-	public Collection<SearchResult> findElement(String elementName, String elementValue);
+	public abstract String getVersion();
 
 }

--- a/tools/tests/com.liferay.ide.upgrade.core.tests/src/com/liferay/blade/test/apichanges/AutoCorrectDescriptorTestBase.java
+++ b/tools/tests/com.liferay.ide.upgrade.core.tests/src/com/liferay/blade/test/apichanges/AutoCorrectDescriptorTestBase.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.blade.test.apichanges;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceReference;
+
+import com.liferay.blade.api.AutoMigrator;
+import com.liferay.blade.api.FileMigrator;
+import com.liferay.blade.api.Problem;
+
+/**
+ * @author Seiphon Wang
+ */
+public abstract class AutoCorrectDescriptorTestBase {
+
+	@Test
+	public void autoCorrectProblems() throws Exception {
+		File tempFolder = Files.createTempDirectory("autocorrect").toFile();
+
+		File testFile = new File(tempFolder, "test.xml");
+
+		tempFolder.deleteOnExit();
+
+		Files.copy(getOriginalTestFile().toPath(), testFile.toPath());
+
+		List<Problem> problems = null;
+		FileMigrator migrator = null;
+
+		Collection<ServiceReference<FileMigrator>> mrefs =
+			context.getServiceReferences(FileMigrator.class, "(version=" + getVersion() + ")");
+
+		for (ServiceReference<FileMigrator> mref : mrefs) {
+			migrator = context.getService(mref);
+
+			Class<?> clazz = migrator.getClass();
+
+			if (clazz.getName().contains(getImplClassName())) {
+				problems = migrator.analyze(testFile);
+
+				break;
+			}
+		}
+
+		Assert.assertEquals("", 1, problems.size());
+
+		File dest = new File(tempFolder, "Updated.xml");
+
+		Files.copy(testFile.toPath(), dest.toPath());
+
+		int problemsFixed = ((AutoMigrator)migrator).correctProblems(dest, problems);
+
+		Assert.assertEquals("", 1, problemsFixed);
+
+		problems = migrator.analyze(dest);
+
+		Assert.assertEquals("", 0, problems.size());
+	}
+
+	public abstract String getImplClassName();
+
+	public abstract File getOriginalTestFile();
+
+	public abstract String getVersion();
+
+	protected BundleContext context = FrameworkUtil.getBundle(getClass()).getBundleContext();
+
+}

--- a/tools/tests/com.liferay.ide.upgrade.core.tests/src/com/liferay/blade/test/apichanges/DescriptorAutoCorrectTest.java
+++ b/tools/tests/com.liferay.ide.upgrade.core.tests/src/com/liferay/blade/test/apichanges/DescriptorAutoCorrectTest.java
@@ -12,18 +12,28 @@
  * details.
  */
 
-package com.liferay.blade.api;
+package com.liferay.blade.test.apichanges;
 
-import java.util.Collection;
-import java.util.regex.Pattern;
+import java.io.File;
 
 /**
- * @author Gregory Amerson
+ * @author Seiphon Wang
  */
-public interface XMLFile extends SourceFile {
+public class DescriptorAutoCorrectTest extends AutoCorrectDescriptorTestBase {
 
-	public SearchResult findDocumentTypeDeclaration(String name, Pattern idPattern);
+	@Override
+	public String getImplClassName() {
+		return "LiferayDescriptorVersion";
+	}
 
-	public Collection<SearchResult> findElement(String elementName, String elementValue);
+	@Override
+	public File getOriginalTestFile() {
+		return new File("projects/legacy-apis-ant-portlet/docroot/WEB-INF/liferay-portlet.xml");
+	}
+
+	@Override
+	public String getVersion() {
+		return "7.0";
+	}
 
 }

--- a/tools/tests/com.liferay.ide.upgrade.core.tests/src/com/liferay/blade/test/apichanges/DescriptorsTest.java
+++ b/tools/tests/com.liferay.ide.upgrade.core.tests/src/com/liferay/blade/test/apichanges/DescriptorsTest.java
@@ -12,18 +12,27 @@
  * details.
  */
 
-package com.liferay.blade.api;
+package com.liferay.blade.test.apichanges;
 
-import java.util.Collection;
-import java.util.regex.Pattern;
+import java.io.File;
 
 /**
- * @author Gregory Amerson
+ * @author Seiphon Wang
  */
-public interface XMLFile extends SourceFile {
+public class DescriptorsTest extends APIVersionSupportTestBase {
 
-	public SearchResult findDocumentTypeDeclaration(String name, Pattern idPattern);
+	@Override
+	public String getImplClassName() {
+		return "LiferayDescriptorVersion";
+	}
 
-	public Collection<SearchResult> findElement(String elementName, String elementValue);
+	@Override
+	public File getTestFile() {
+		return new File("projects/legacy-apis-ant-portlet/docroot/WEB-INF/liferay-portlet.xml");
+	}
 
+	@Override
+	public String getVersion() {
+		return "7.0";
+	}
 }

--- a/tools/tests/com.liferay.ide.upgrade.core.tests/src/com/liferay/blade/test/apichanges71/DescriptorAutoCorrect71Test.java
+++ b/tools/tests/com.liferay.ide.upgrade.core.tests/src/com/liferay/blade/test/apichanges71/DescriptorAutoCorrect71Test.java
@@ -12,18 +12,29 @@
  * details.
  */
 
-package com.liferay.blade.api;
+package com.liferay.blade.test.apichanges71;
 
-import java.util.Collection;
-import java.util.regex.Pattern;
+import java.io.File;
+
+import com.liferay.blade.test.apichanges.AutoCorrectDescriptorTestBase;
 
 /**
- * @author Gregory Amerson
+ * @author Seiphon Wang
  */
-public interface XMLFile extends SourceFile {
+public class DescriptorAutoCorrect71Test extends AutoCorrectDescriptorTestBase {
 
-	public SearchResult findDocumentTypeDeclaration(String name, Pattern idPattern);
+	@Override
+	public String getImplClassName() {
+		return "LiferayDescriptorVersion";
+	}
 
-	public Collection<SearchResult> findElement(String elementName, String elementValue);
+	@Override
+	public File getOriginalTestFile() {
+		return new File("projects/legacy-apis-ant-portlet/docroot/WEB-INF/liferay-portlet.xml");
+	}
 
+	@Override
+	public String getVersion() {
+		return "7.1";
+	}
 }

--- a/tools/tests/com.liferay.ide.upgrade.core.tests/src/com/liferay/blade/test/apichanges71/Descriptors71Test.java
+++ b/tools/tests/com.liferay.ide.upgrade.core.tests/src/com/liferay/blade/test/apichanges71/Descriptors71Test.java
@@ -12,18 +12,29 @@
  * details.
  */
 
-package com.liferay.blade.api;
+package com.liferay.blade.test.apichanges71;
 
-import java.util.Collection;
-import java.util.regex.Pattern;
+import java.io.File;
+
+import com.liferay.blade.test.apichanges.APIVersionSupportTestBase;
 
 /**
- * @author Gregory Amerson
+ * @author Seiphon Wang
  */
-public interface XMLFile extends SourceFile {
+public class Descriptors71Test extends APIVersionSupportTestBase {
 
-	public SearchResult findDocumentTypeDeclaration(String name, Pattern idPattern);
+	@Override
+	public String getImplClassName() {
+		return "LiferayDescriptorVersion";
+	}
 
-	public Collection<SearchResult> findElement(String elementName, String elementValue);
+	@Override
+	public File getTestFile() {
+		return new File("projects/legacy-apis-ant-portlet/docroot/WEB-INF/liferay-portlet.xml");
+	}
 
+	@Override
+	public String getVersion() {
+		return "7.1";
+	}
 }


### PR DESCRIPTION
Hi @jtydhr88 

I found the result of InitJSPParseTest is not stable because of that parallel is not thread-safe. ParalleStream and forEach can not be synchronization sometimes, can refer this [link](https://stackoverflow.com/questions/22350288/parallel-streams-collectors-and-thread-safety).

My solution is using forEachOrdered replace forEach, it maybe reduce a little bit parallel performance, but it still parallelize efficiently even under ordering constraints. please refer this [link](https://docs.oracle.com/javase/8/docs/api/java/util/stream/package-summary.html).

Br,
Seiphon