### PR TITLE
IDE-4470 use maven timestamp as the version of installers

### DIFF
--- a/build/installers/components/create-timestamp.xml
+++ b/build/installers/components/create-timestamp.xml
@@ -1,4 +1,0 @@
-<createTimeStamp>
-    <format>%Y%m%d%H%M</format>
-    <variable>timestamp</variable>
-</createTimeStamp>

--- a/build/installers/liferay-project-sdk-with-devstudio-ce/liferay-project-sdk-with-devstudio-ce.xml
+++ b/build/installers/liferay-project-sdk-with-devstudio-ce/liferay-project-sdk-with-devstudio-ce.xml
@@ -1,7 +1,6 @@
 <project>
     <shortName>LiferayProjectSDKwithDevStudioCommunityEdition</shortName>
     <fullName>Liferay Project SDK with DevStudio - Community Edition</fullName>
-    <version>${timestamp}</version>
     <logoImage>../shared/images/studio_logo.png</logoImage>
     <componentList>
         <component>
@@ -61,9 +60,6 @@
         <include file="../components/devstudio-osxcomponent.xml" />
         <include file="../components/devstudio-wincomponent.xml" />
     </componentList>
-    <preBuildActionList>
-        <include file="../components/create-timestamp.xml" />
-    </preBuildActionList>
     <preInstallationActionList>
         <include file="../components/autodetect-java.xml" />
     </preInstallationActionList>

--- a/build/installers/liferay-project-sdk-with-devstudio-ce/pom.xml
+++ b/build/installers/liferay-project-sdk-with-devstudio-ce/pom.xml
@@ -31,7 +31,7 @@
     <name>Liferay Project SDK with DevStudio Community Edition Installer</name>
 
     <properties>
-        <studio-installer-version>2018.12.11</studio-installer-version>
+        <studio-installer-version>${maven.build.timestamp}</studio-installer-version>
     </properties>
 
     <build>
@@ -163,6 +163,8 @@
                                 <argument>build</argument>
                                 <argument>./liferay-project-sdk-with-devstudio-ce.xml</argument>
                                 <argument>linux-x64</argument>
+                                <argument>--setvars</argument>
+                                <argument>project.version=${studio-installer-version}</argument>
                             </arguments>
                         </configuration>
                     </execution>
@@ -178,6 +180,8 @@
                                 <argument>build</argument>
                                 <argument>./liferay-project-sdk-with-devstudio-ce.xml</argument>
                                 <argument>windows</argument>
+                                <argument>--setvars</argument>
+                                <argument>project.version=${studio-installer-version}</argument>
                             </arguments>
                         </configuration>
                     </execution>
@@ -193,6 +197,8 @@
                                 <argument>build</argument>
                                 <argument>./liferay-project-sdk-with-devstudio-ce.xml</argument>
                                 <argument>osx</argument>
+                                <argument>--setvars</argument>
+                                <argument>project.version=${studio-installer-version}</argument>
                             </arguments>
                         </configuration>
                     </execution>

--- a/build/installers/liferay-project-sdk-with-devstudio-dxp/liferay-project-sdk-with-devstudio-dxp.xml
+++ b/build/installers/liferay-project-sdk-with-devstudio-dxp/liferay-project-sdk-with-devstudio-dxp.xml
@@ -1,7 +1,6 @@
 <project>
     <shortName>LiferayProjectSDKwithDevStudioDXP</shortName>
     <fullName>Liferay Project SDK with DevStudio - DXP</fullName>
-    <version>${timestamp}</version>
     <logoImage>../shared/images/studio_logo.png</logoImage>
     <componentList>
         <component>
@@ -61,9 +60,6 @@
         <include file="../components/devstudio-osxcomponent.xml" />
         <include file="../components/devstudio-wincomponent.xml" />
     </componentList>
-    <preBuildActionList>
-        <include file="../components/create-timestamp.xml" />
-    </preBuildActionList>
     <preInstallationActionList>
         <include file="../components/autodetect-java.xml" />
     </preInstallationActionList>

--- a/build/installers/liferay-project-sdk-with-devstudio-dxp/pom.xml
+++ b/build/installers/liferay-project-sdk-with-devstudio-dxp/pom.xml
@@ -31,7 +31,7 @@
     <name>Liferay Project SDK with DevStudio DXP Installer</name>
 
     <properties>
-        <studio-installer-version>2018.12.11</studio-installer-version>
+        <studio-installer-version>${maven.build.timestamp}</studio-installer-version>
     </properties>
 
     <build>
@@ -163,6 +163,8 @@
                                 <argument>build</argument>
                                 <argument>./liferay-project-sdk-with-devstudio-dxp.xml</argument>
                                 <argument>linux-x64</argument>
+                                <argument>--setvars</argument>
+                                <argument>project.version=${studio-installer-version}</argument>
                             </arguments>
                         </configuration>
                     </execution>
@@ -178,6 +180,8 @@
                                 <argument>build</argument>
                                 <argument>./liferay-project-sdk-with-devstudio-dxp.xml</argument>
                                 <argument>windows</argument>
+                                <argument>--setvars</argument>
+                                <argument>project.version=${studio-installer-version}</argument>
                             </arguments>
                         </configuration>
                     </execution>
@@ -193,6 +197,8 @@
                                 <argument>build</argument>
                                 <argument>./liferay-project-sdk-with-devstudio-dxp.xml</argument>
                                 <argument>osx</argument>
+                                <argument>--setvars</argument>
+                                <argument>project.version=${studio-installer-version}</argument>
                             </arguments>
                         </configuration>
                     </execution>

--- a/build/installers/liferay-project-sdk/liferay-project-sdk.xml
+++ b/build/installers/liferay-project-sdk/liferay-project-sdk.xml
@@ -1,7 +1,6 @@
 <project>
     <shortName>LiferayProjectSDK</shortName>
     <fullName>Liferay Project SDK</fullName>
-    <version>${timestamp}</version>
     <logoImage>../shared/images/liferay_logo_large.png</logoImage>
     <componentList>
         <component>
@@ -55,9 +54,6 @@
             </folderList>
         </component>
     </componentList>
-    <preBuildActionList>
-        <include file="../components/create-timestamp.xml" />
-    </preBuildActionList>
     <preInstallationActionList>
         <include file="../components/autodetect-java.xml" />
     </preInstallationActionList>

--- a/build/installers/liferay-project-sdk/pom.xml
+++ b/build/installers/liferay-project-sdk/pom.xml
@@ -31,7 +31,7 @@
     <name>Liferay Project SDK Installer</name>
 
     <properties>
-        <workspace-installer-version>2018.12.11</workspace-installer-version>
+        <workspace-installer-version>${maven.build.timestamp}</workspace-installer-version>
     </properties>
 
     <build>
@@ -152,6 +152,8 @@
                                 <argument>build</argument>
                                 <argument>./liferay-project-sdk.xml</argument>
                                 <argument>linux-x64</argument>
+                                <argument>--setvars</argument>
+                                <argument>project.version=${workspace-installer-version}</argument>
                             </arguments>
                         </configuration>
                     </execution>
@@ -167,6 +169,8 @@
                                 <argument>build</argument>
                                 <argument>./liferay-project-sdk.xml</argument>
                                 <argument>windows</argument>
+                                <argument>--setvars</argument>
+                                <argument>project.version=${workspace-installer-version}</argument>
                             </arguments>
                         </configuration>
                     </execution>
@@ -182,6 +186,8 @@
                                 <argument>build</argument>
                                 <argument>./liferay-project-sdk.xml</argument>
                                 <argument>osx</argument>
+                                <argument>--setvars</argument>
+                                <argument>project.version=${workspace-installer-version}</argument>
                             </arguments>
                         </configuration>
                     </execution>

--- a/build/installers/pom.xml
+++ b/build/installers/pom.xml
@@ -50,6 +50,7 @@
         <jpmcli-latest-md5>c23d4c900794ad20aca0321f70d6edb5</jpmcli-latest-md5>
         <bnd-latest-download-url>https://repository-cdn.liferay.com/nexus/content/groups/public/biz/aQute/bnd/biz.aQute.bnd/3.5.0/biz.aQute.bnd-3.5.0.jar</bnd-latest-download-url>
         <bnd-latest-md5>19983bd645ec65d162355bd4dac910fa</bnd-latest-md5>
+        <maven.build.timestamp.format>yyyyMMddHHmm</maven.build.timestamp.format>
     </properties>
 
     <modules>


### PR DESCRIPTION
Hello @gamerson  and @jtydhr88,

After investigation, we can pass the ${maven.build.timestamp} to maven-exec-plugin during build instead of XML file since the property can't be access directly in XML file. Now they have the same timestamps.