### PR TITLE
IDE-4467 update to eclipse 201812

### DIFF
--- a/build/com.liferay.ide-repository/bundle/bundle.properties
+++ b/build/com.liferay.ide-repository/bundle/bundle.properties
@@ -16,11 +16,11 @@ builder.zip.url=http://archive.eclipse.org/technology/epp/downloads/release/mars
 
 ## 64-bit OSes
 
-eclipse.win64.zip.name=eclipse-jee-photon-R-win32-x86_64.zip
-eclipse.win64.zip.url=http://eclipse.mirror.rafal.ca/technology/epp/downloads/release/photon/R/eclipse-jee-photon-R-win32-x86_64.zip
-eclipse.linux64.zip.name=eclipse-jee-photon-R-linux-gtk-x86_64.tar.gz
-eclipse.linux64.tar.name=eclipse-jee-photon-R-linux-gtk-x86_64.tar
-eclipse.linux64.zip.url=http://eclipse.mirror.rafal.ca/technology/epp/downloads/release/photon/R/eclipse-jee-photon-R-linux-gtk-x86_64.tar.gz
+eclipse.win64.zip.name=eclipse-jee-2018-12-R-win32-x86_64.zip
+eclipse.win64.zip.url=http://eclipse.mirror.rafal.ca/technology/epp/downloads/release/2018-12/R/eclipse-jee-2018-12-R-win32-x86_64.zip
+eclipse.linux64.zip.name=eclipse-jee-2018-12-R-linux-gtk-x86_64.tar.gz
+eclipse.linux64.tar.name=eclipse-jee-2018-12-R-linux-gtk-x86_64.tar
+eclipse.linux64.zip.url=http://eclipse.mirror.rafal.ca/technology/epp/downloads/release/2018-12/R/eclipse-jee-2018-12-R-linux-gtk-x86_64.tar.gz
 #eclipse.macosx64.zip.name=eclipse-jee-neon-3-macosx-cocoa-x86_64.tar.gz
 #eclipse.macosx64.tar.name=eclipse-jee-neon-3-macosx-cocoa-x86_64.tar
 #eclipse.macosx64.zip.url=http://eclipse.mirror.rafal.ca/technology/epp/downloads/release/neon/3/eclipse-jee-neon-3-macosx-cocoa-x86_64.tar.gz

--- a/build/com.liferay.ide-repository/studio.product
+++ b/build/com.liferay.ide-repository/studio.product
@@ -125,12 +125,9 @@ to distribution rights of the Software.
 
       <feature id="org.eclipse.jdt" installMode="root"/>
 
-      <feature id="org.eclipse.jpt.common.eclipselink.feature" installMode="root"/>
+
       <feature id="org.eclipse.jpt.common.feature" installMode="root"/>
-      <feature id="org.eclipse.jpt.dbws.eclipselink.feature" installMode="root"/>
-      <feature id="org.eclipse.jpt.jaxb.eclipselink.feature" installMode="root"/>
       <feature id="org.eclipse.jpt.jaxb.feature" installMode="root"/>
-      <feature id="org.eclipse.jpt.jpa.eclipselink.feature" installMode="root"/>
       <feature id="org.eclipse.jpt.jpa.feature" installMode="root"/>
 
       <feature id="org.eclipse.jsf.feature"  installMode="root"/>
@@ -167,8 +164,6 @@ to distribution rights of the Software.
 
       <feature id="org.eclipse.pde" installMode="root"/>
 
-      <feature id="org.eclipse.recommenders.mylyn.rcp.feature" installMode="root"/>
-      <feature id="org.eclipse.recommenders.rcp.feature" installMode="root"/>
       <feature id="org.eclipse.rse" installMode="root"/>
       <feature id="org.eclipse.rse.useractions" installMode="root"/>
       <feature id="org.eclipse.tm.terminal.feature" installMode="root"/>

--- a/build/com.liferay.ide-repository/studio.product
+++ b/build/com.liferay.ide-repository/studio.product
@@ -176,6 +176,7 @@ to distribution rights of the Software.
       <feature id="org.eclipse.wst.xml_ui.feature" installMode="root"/>
       <feature id="org.eclipse.wst.xsl.feature" installMode="root"/>
       <feature id="org.eclipse.epp.logging.aeri.feature" installMode="root"/>
+      <feature id="org.eclipse.equinox.core.feature" installMode="root"/>
    </features>
 
    <configurations>

--- a/build/parent/pom.xml
+++ b/build/parent/pom.xml
@@ -32,7 +32,7 @@
         <tycho-extras-version>1.0.0</tycho-extras-version>
         <eclipse-site>https://download.eclipse.org/releases/2018-12/201812191000/</eclipse-site>
         <orbit-site>http://download.eclipse.org/tools/orbit/downloads/drops/R20180606145124/repository/</orbit-site>
-        <tm-site>http://download.eclipse.org/tm/terminal/updates/4.4milestones/20180611/</tm-site>
+        <tm-site>https://download.eclipse.org/tm/updates/4.5.0/repository/</tm-site>
         <liferay-ide-swtbot-testing-site>http://files.liferay.org.es/staged/public-files/liferay-ide/unstable/build/com.liferay.ide.testing-repository/target/repository/</liferay-ide-swtbot-testing-site>
         <osgi-bundles-site>https://repos-ide.wedeploy.io/liferay-ide-osgi-deps/</osgi-bundles-site>
         <ivy-site>https://dist.apache.org/repos/dist/release/ant/ivyde/updatesite/ivy-2.4.0.final_20141213170938/</ivy-site>

--- a/build/parent/pom.xml
+++ b/build/parent/pom.xml
@@ -30,7 +30,7 @@
         <tycho-packaging-format>yyyyMMddHHmm</tycho-packaging-format>
         <tycho-version>1.3.0</tycho-version>
         <tycho-extras-version>1.0.0</tycho-extras-version>
-        <eclipse-site>http://download.eclipse.org/releases/photon/201806271001/</eclipse-site>
+        <eclipse-site>https://download.eclipse.org/releases/2018-12/</eclipse-site>
         <orbit-site>http://download.eclipse.org/tools/orbit/downloads/drops/R20180606145124/repository/</orbit-site>
         <tm-site>http://download.eclipse.org/tm/terminal/updates/4.4milestones/20180611/</tm-site>
         <liferay-ide-swtbot-testing-site>http://files.liferay.org.es/staged/public-files/liferay-ide/unstable/build/com.liferay.ide.testing-repository/target/repository/</liferay-ide-swtbot-testing-site>
@@ -38,7 +38,7 @@
         <ivy-site>https://dist.apache.org/repos/dist/release/ant/ivyde/updatesite/ivy-2.4.0.final_20141213170938/</ivy-site>
         <ivyde-site>https://dist.apache.org/repos/dist/release/ant/ivyde/updatesite/ivyde-2.2.0.final-201311091524-RELEASE/</ivyde-site>
         <m2e-site>http://download.eclipse.org/technology/m2e/releases/1.9/1.9.0.20180606-2036/</m2e-site>
-        <m2e-wtp-site>http://download.eclipse.org/m2e-wtp/releases/photon/1.4/1.4.0.20180606-2005/</m2e-wtp-site>
+        <m2e-wtp-site>https://download.eclipse.org/m2e-wtp/releases/1.4/1.4.1.20181128-2152</m2e-wtp-site>
         <m2e-archiver-site>http://repo1.maven.org/maven2/.m2e/connectors/m2eclipse-mavenarchiver/0.17.2/N/0.17.2.201606141937/</m2e-archiver-site>
         <eclipse-xml-search-site>https://dl.bintray.com/gamerson/eclipse-wtp-xml-search/</eclipse-xml-search-site>
         <tern-site>http://oss.opensagres.fr/tern.repository/1.2.1/</tern-site>

--- a/build/parent/pom.xml
+++ b/build/parent/pom.xml
@@ -37,7 +37,7 @@
         <osgi-bundles-site>https://repos-ide.wedeploy.io/liferay-ide-osgi-deps/</osgi-bundles-site>
         <ivy-site>https://dist.apache.org/repos/dist/release/ant/ivyde/updatesite/ivy-2.4.0.final_20141213170938/</ivy-site>
         <ivyde-site>https://dist.apache.org/repos/dist/release/ant/ivyde/updatesite/ivyde-2.2.0.final-201311091524-RELEASE/</ivyde-site>
-        <m2e-site>http://download.eclipse.org/technology/m2e/releases/1.9/1.9.0.20180606-2036/</m2e-site>
+        <m2e-site>http://download.eclipse.org/technology/m2e/releases/1.10/1.10.0.20181127-2120/</m2e-site>
         <m2e-wtp-site>https://download.eclipse.org/m2e-wtp/releases/1.4/1.4.1.20181128-2152</m2e-wtp-site>
         <m2e-archiver-site>http://repo1.maven.org/maven2/.m2e/connectors/m2eclipse-mavenarchiver/0.17.2/N/0.17.2.201606141937/</m2e-archiver-site>
         <eclipse-xml-search-site>https://dl.bintray.com/gamerson/eclipse-wtp-xml-search/</eclipse-xml-search-site>

--- a/build/parent/pom.xml
+++ b/build/parent/pom.xml
@@ -30,7 +30,7 @@
         <tycho-packaging-format>yyyyMMddHHmm</tycho-packaging-format>
         <tycho-version>1.3.0</tycho-version>
         <tycho-extras-version>1.0.0</tycho-extras-version>
-        <eclipse-site>https://download.eclipse.org/releases/2018-12/</eclipse-site>
+        <eclipse-site>https://download.eclipse.org/releases/2018-12/201812191000/</eclipse-site>
         <orbit-site>http://download.eclipse.org/tools/orbit/downloads/drops/R20180606145124/repository/</orbit-site>
         <tm-site>http://download.eclipse.org/tm/terminal/updates/4.4milestones/20180611/</tm-site>
         <liferay-ide-swtbot-testing-site>http://files.liferay.org.es/staged/public-files/liferay-ide/unstable/build/com.liferay.ide.testing-repository/target/repository/</liferay-ide-swtbot-testing-site>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -32,7 +32,7 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<eclipse-site>http://download.eclipse.org/releases/photon/201806271001/</eclipse-site>
+		<eclipse-site>https://download.eclipse.org/releases/2018-12/201812191000/</eclipse-site>
 		<tycho-version>1.0.0</tycho-version>
 		<liferay-ide-site>http://files.liferay.org.es/staged/public-files/liferay-ide/unstable/build/com.liferay.ide-repository/target/repository/</liferay-ide-site>
 	</properties>

--- a/tools/features/com.liferay.ide.hidden/feature.xml
+++ b/tools/features/com.liferay.ide.hidden/feature.xml
@@ -61,7 +61,7 @@
 		unpack="false"
 		version="0.0.0"
 	/>
-<!--
+	<!--
 	<plugin
 		download-size="0"
 		id="com.gradleware.tooling.client"
@@ -178,7 +178,7 @@
 		id="org.objectweb.asm"
 		install-size="0"
 		unpack="false"
-		version="0.0.0"
+		version="5.2.0.v20170126-0011"
 	/>
 
 	<plugin
@@ -186,7 +186,7 @@
 		id="org.objectweb.asm"
 		install-size="0"
 		unpack="false"
-		version="0.0.0"
+		version="6.0.0.v20180414-0329"
 	/>
 	<plugin
 		download-size="0"

--- a/tools/features/com.liferay.ide.hidden/feature.xml
+++ b/tools/features/com.liferay.ide.hidden/feature.xml
@@ -61,7 +61,7 @@
 		unpack="false"
 		version="0.0.0"
 	/>
-
+<!--
 	<plugin
 		download-size="0"
 		id="com.gradleware.tooling.client"
@@ -85,7 +85,7 @@
 		unpack="false"
 		version="0.0.0"
 	/>
-
+-->
 	<plugin
 		download-size="0"
 		id="minimal-json"
@@ -173,13 +173,12 @@
 		unpack="false"
 		version="0.0.0"
 	/>
-
 	<plugin
 		download-size="0"
 		id="org.objectweb.asm"
 		install-size="0"
 		unpack="false"
-		version="5.2.0.v20170126-0011"
+		version="0.0.0"
 	/>
 
 	<plugin
@@ -187,9 +186,8 @@
 		id="org.objectweb.asm"
 		install-size="0"
 		unpack="false"
-		version="6.0.0.v20180116-1719"
+		version="0.0.0"
 	/>
-
 	<plugin
 		download-size="0"
 		id="javax.websocket-api"

--- a/ui-tests/pom.xml
+++ b/ui-tests/pom.xml
@@ -32,7 +32,7 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<eclipse-site>http://download.eclipse.org/releases/photon/201806271001/</eclipse-site>
+		<eclipse-site>https://download.eclipse.org/releases/2018-12/201812191000/</eclipse-site>
 		<tycho-version>1.0.0</tycho-version>
 		<liferay-ide-site>http://files.liferay.org.es/staged/public-files/liferay-ide/unstable/build/com.liferay.ide-repository/target/repository/</liferay-ide-site>
 	</properties>


### PR DESCRIPTION
With this commits, we still can install our updatesite to Eclipse Photon and greater successfully.