### PR TITLE
IDE-4558 Fix build services action could not find projects issue

### DIFF
--- a/tools/plugins/com.liferay.ide.upgrade.tasks.core/src/com/liferay/ide/upgrade/tasks/core/ResourceSelection.java
+++ b/tools/plugins/com.liferay.ide.upgrade.tasks.core/src/com/liferay/ide/upgrade/tasks/core/ResourceSelection.java
@@ -81,7 +81,7 @@ public interface ResourceSelection {
 			).filter(
 				Objects::nonNull
 			).filter(
-				p -> !(p instanceof NoopLiferayProject)
+				p -> p instanceof NoopLiferayProject
 			).isPresent();
 
 			return result;


### PR DESCRIPTION
Hi @jtydhr88 

For this issue, I am not sure this fix is right or not. Because I have no idea about why do we need a filter to exclude NoopLiferayProject. And it seems service-builder projects belong to NoopLiferayProject, I am confused about that.

After using my fix, the service builder action still have a NullPointerException,  I will continue work on that.

Br,
Seiphon