### PR TITLE
IDE-4616 find and remove <wap-template-path> tag in layout-template on 7.x

### DIFF
--- a/tools/plugins/com.liferay.ide.upgrade.problems.core/META-INF/MANIFEST.MF
+++ b/tools/plugins/com.liferay.ide.upgrade.problems.core/META-INF/MANIFEST.MF
@@ -169,4 +169,5 @@ Service-Component: OSGI-INF/com.liferay.ide.upgrade.problems.core.internal.SSEXM
  OSGI-INF/com.liferay.ide.upgrade.problems.core.internal.liferay72.SwitchToUseJDKFunctionAndSupplier.xml,
  OSGI-INF/com.liferay.ide.upgrade.problems.core.internal.liferay72.DroppedSupportOfServiceLoaderCondition.xml,
  OSGI-INF/com.liferay.ide.upgrade.problems.core.internal.liferay72.RemovedSupportForJSPTemplates.xml,
- OSGI-INF/com.liferay.ide.upgrade.problems.core.internal.liferay72.RemovedUnsafeFunctionalInterface.xml
+ OSGI-INF/com.liferay.ide.upgrade.problems.core.internal.liferay72.RemovedUnsafeFunctionalInterface.xml,
+ OSGI-INF/com.liferay.ide.upgrade.problems.core.internal.liferay70.DeprecatedLayoutTemplateTags.xml

--- a/tools/plugins/com.liferay.ide.upgrade.problems.core/OSGI-INF/com.liferay.ide.upgrade.problems.core.internal.liferay70.DeprecatedLayoutTemplateTags.xml
+++ b/tools/plugins/com.liferay.ide.upgrade.problems.core/OSGI-INF/com.liferay.ide.upgrade.problems.core.internal.liferay70.DeprecatedLayoutTemplateTags.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" name="com.liferay.ide.upgrade.problems.core.internal.liferay70.DeprecatedLayoutTemplateTags">
+   <property name="file.extensions" value="xml"/>
+   <property name="problem.title" value="Deprecated wap-template-path tag on 7.x for layout templates"/>
+   <property name="problem.summary" value="The &lt;wap-template-path&gt; tag was deprecated on 7.x for layout-templates."/>
+   <property name="auto.correct" value="wap-template-path"/>
+   <property name="problem.section" value="#deprecated-wap-template-path-for-layout-templates"/>
+   <property name="version" value="7.0"/>
+   <service>
+      <provide interface="com.liferay.ide.upgrade.problems.core.AutoFileMigrator"/>
+      <provide interface="com.liferay.ide.upgrade.problems.core.FileMigrator"/>
+   </service>
+   <implementation class="com.liferay.ide.upgrade.problems.core.internal.liferay70.DeprecatedLayoutTemplateTags"/>
+</scr:component>

--- a/tools/plugins/com.liferay.ide.upgrade.problems.core/src/com/liferay/ide/upgrade/problems/core/XMLFile.java
+++ b/tools/plugins/com.liferay.ide.upgrade.problems.core/src/com/liferay/ide/upgrade/problems/core/XMLFile.java
@@ -29,4 +29,6 @@ public interface XMLFile extends SourceFile {
 	public Collection<FileSearchResult> findElementAttribute(
 		String tagName, String attributeName, Pattern valuePattern);
 
+	public Collection<FileSearchResult> findElementByName(String elementName);
+
 }

--- a/tools/plugins/com.liferay.ide.upgrade.problems.core/src/com/liferay/ide/upgrade/problems/core/internal/SSEXMLFile.java
+++ b/tools/plugins/com.liferay.ide.upgrade.problems.core/src/com/liferay/ide/upgrade/problems/core/internal/SSEXMLFile.java
@@ -24,6 +24,7 @@ import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -199,6 +200,55 @@ public class SSEXMLFile extends WorkspaceFile implements XMLFile {
 					result.autoCorrectContext = "layout-template:css-class";
 
 					results.add(result);
+				}
+			}
+		}
+		catch (Exception e) {
+		}
+		finally {
+			if (domModel != null) {
+				domModel.releaseFromRead();
+			}
+		}
+
+		return results;
+	}
+
+	@Override
+	@SuppressWarnings("deprecation")
+	public Collection<FileSearchResult> findElementByName(String elementName) {
+		List<FileSearchResult> results = new ArrayList<>();
+
+		IDOMModel domModel = null;
+
+		try {
+			IModelManager modelManager = StructuredModelManager.getModelManager();
+
+			try (InputStream input = Files.newInputStream(Paths.get(file.toURI()), StandardOpenOption.READ)) {
+				domModel = (IDOMModel)modelManager.getModelForRead(file.getAbsolutePath(), input, null);
+			}
+
+			IDOMDocument domDocument = domModel.getDocument();
+
+			NodeList elements = domDocument.getElementsByTagName(elementName);
+
+			if (elements != null) {
+				for (int i = 0; i < elements.getLength(); i++) {
+					IDOMElement element = (IDOMElement)elements.item(i);
+
+					if (element != null) {
+						IStructuredDocument structuredDocument = domDocument.getStructuredDocument();
+
+						int startOffset = element.getStartOffset();
+						int endOffset = element.getEndOffset();
+						int startLine = structuredDocument.getLineOfOffset(startOffset) + 1;
+						int endLine = structuredDocument.getLineOfOffset(endOffset) + 1;
+
+						FileSearchResult result = new FileSearchResult(
+							file, "startOffset:" + startOffset, startOffset, endOffset, startLine, endLine, true);
+
+						results.add(result);
+					}
 				}
 			}
 		}

--- a/tools/plugins/com.liferay.ide.upgrade.problems.core/src/com/liferay/ide/upgrade/problems/core/internal/liferay70/BREAKING_CHANGES.markdown
+++ b/tools/plugins/com.liferay.ide.upgrade.problems.core/src/com/liferay/ide/upgrade/problems/core/internal/liferay70/BREAKING_CHANGES.markdown
@@ -4465,3 +4465,25 @@ sync both components, and simplify its internal logic, activity sets are always
 enabled by default, with no option to disable them.
 
 ---------------------------------------
+
+### Deprecated wap-template-path tag on 7.x for layout templates [](id=deprecated-wap-template-path-for-layout-templates)
+- **Date:** 2019-Jul-30
+- **JIRA Ticket:**
+
+#### What changed? [](id=what-changed-114)
+
+The <wap-template-path> tag doesn't exist on liferay portal 7.0 anymore.
+
+#### Who is affected? [](id=who-is-affected-114)
+
+This change affects liferay-layout-template.xml in layout templates.
+
+#### How should I update my code? [](id=how-should-i-update-my-code-114)
+
+Remove <wap-template-path> tag.
+
+#### Why was this change made? [](id=why-was-this-change-made-114)
+
+The <wap-template-path> tag was deprecated on 7.x for layout-templates.
+
+---------------------------------------

--- a/tools/plugins/com.liferay.ide.upgrade.problems.core/src/com/liferay/ide/upgrade/problems/core/internal/liferay70/DeprecatedLayoutTemplateTags.java
+++ b/tools/plugins/com.liferay.ide.upgrade.problems.core/src/com/liferay/ide/upgrade/problems/core/internal/liferay70/DeprecatedLayoutTemplateTags.java
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.ide.upgrade.problems.core.internal.liferay70;
+
+import com.liferay.ide.upgrade.plan.core.UpgradeProblem;
+import com.liferay.ide.upgrade.problems.core.AutoFileMigrateException;
+import com.liferay.ide.upgrade.problems.core.AutoFileMigrator;
+import com.liferay.ide.upgrade.problems.core.FileMigrator;
+import com.liferay.ide.upgrade.problems.core.FileSearchResult;
+import com.liferay.ide.upgrade.problems.core.XMLFile;
+import com.liferay.ide.upgrade.problems.core.internal.XMLFileMigrator;
+
+import java.io.File;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.wst.sse.core.StructuredModelManager;
+import org.eclipse.wst.sse.core.internal.provisional.IModelManager;
+import org.eclipse.wst.sse.core.internal.provisional.IndexedRegion;
+import org.eclipse.wst.xml.core.internal.provisional.document.IDOMElement;
+import org.eclipse.wst.xml.core.internal.provisional.document.IDOMModel;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Seiphon Wang
+ */
+@Component(
+	property = {
+		"file.extensions=xml", "problem.title=Deprecated wap-template-path tag on 7.x for layout templates",
+		"problem.summary=The <wap-template-path> tag was deprecated on 7.x for layout-templates.",
+		"auto.correct=wap-template-path", "problem.section=#deprecated-wap-template-path-for-layout-templates",
+		"version=7.0"
+	},
+	service = {AutoFileMigrator.class, FileMigrator.class}
+)
+@SuppressWarnings("restriction")
+public class DeprecatedLayoutTemplateTags extends XMLFileMigrator implements AutoFileMigrator {
+
+	@Override
+	@SuppressWarnings("deprecation")
+	public int correctProblems(File file, Collection<UpgradeProblem> upgradeProblems) throws AutoFileMigrateException {
+		int problemsCorrected = 0;
+		IDOMModel domModel = null;
+
+		try {
+			IModelManager modelManager = StructuredModelManager.getModelManager();
+
+			try (InputStream input = Files.newInputStream(Paths.get(file.toURI()), StandardOpenOption.READ)) {
+				domModel = (IDOMModel)modelManager.getModelForEdit(file.getAbsolutePath(), input, null);
+			}
+
+			List<IDOMElement> elementsToCorrect = new ArrayList<>();
+
+			for (UpgradeProblem upgradeProblem : upgradeProblems) {
+				if (_KEY.equals(upgradeProblem.getAutoCorrectContext())) {
+					IndexedRegion region = domModel.getIndexedRegion(upgradeProblem.getStartOffset());
+
+					if (region instanceof IDOMElement) {
+						IDOMElement element = (IDOMElement)region;
+
+						elementsToCorrect.add(element);
+					}
+				}
+			}
+
+			for (IDOMElement element : elementsToCorrect) {
+				domModel.aboutToChangeModel();
+
+				IDOMElement parentElement = (IDOMElement)element.getParentNode();
+
+				parentElement.removeChild(element);
+
+				domModel.changedModel();
+
+				problemsCorrected++;
+			}
+
+			if (problemsCorrected > 0) {
+				try (OutputStream output = Files.newOutputStream(
+						Paths.get(file.toURI()), StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.DSYNC)) {
+
+					domModel.save(output);
+				}
+			}
+		}
+		catch (Exception e) {
+			throw new AutoFileMigrateException("Error writing corrected file", e);
+		}
+		finally {
+			if (domModel != null) {
+				domModel.releaseFromEdit();
+			}
+		}
+
+		return problemsCorrected;
+	}
+
+	@Override
+	protected List<FileSearchResult> searchFile(File file, XMLFile xmlFileChecker) {
+		if (!"liferay-layout-templates.xml".equals(file.getName())) {
+			return Collections.emptyList();
+		}
+
+		List<FileSearchResult> results = new ArrayList<>();
+
+		Collection<FileSearchResult> tags = xmlFileChecker.findElementByName(_KEY);
+
+		for (FileSearchResult tagResult : tags) {
+			tagResult.autoCorrectContext = _KEY;
+		}
+
+		results.addAll(tags);
+
+		return results;
+	}
+
+	private static final String _KEY = "wap-template-path";
+
+}


### PR DESCRIPTION
Hi @jtydhr88
`try (OutputStream output = Files.newOutputStream(
							Paths.get(file.toURI()), StandardOpenOption.WRITE, StandardOpenOption.DSYNC))`

In this code, using 'StandardOpenOption.WRITE' will cause some problems, and I found it exist in many files of our code. If using 'StandardOpenOption.TRUNCATE_EXISTING' instead, the problem will not happen.

So, should I find all the code where using "StandardOpenOption.WRITE" and modify them?